### PR TITLE
In the docker-compose.yml file, server5 hostname was server4, but it should be server5.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,6 +30,6 @@ services:
       - /var/run/docker.sock:/var/run/docker.sock
   server5:
     image: ansible-test-node
-    hostname: server4
+    hostname: server5
     volumes: 
       - /var/run/docker.sock:/var/run/docker.sock


### PR DESCRIPTION
in the docker-compose.yml file, server5 hostname was server4, but it should be server5.

![DeepinScreenshot_select-area_20220126022151](https://user-images.githubusercontent.com/62378019/151053482-9e4cc440-39f0-4f20-b075-7247e061f173.png)


