### PR TITLE
Id rsa file permission change

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,7 @@ services:
       context: ./master
     volumes:
       - ./master/playbooks:/playbooks:ro
+    container_name: master
   server1:
     image: ansible-test-node
     build:
@@ -13,23 +14,28 @@ services:
     hostname: server1
     volumes: 
       - /var/run/docker.sock:/var/run/docker.sock
+    container_name: server1
   server2:
     image: ansible-test-node
     hostname: server2
     volumes: 
       - /var/run/docker.sock:/var/run/docker.sock
+    container_name: server2
   server3:
     image: ansible-test-node
     hostname: server3
     volumes: 
       - /var/run/docker.sock:/var/run/docker.sock
+    container_name: server3
   server4:
     image: ansible-test-node
     hostname: server4
     volumes: 
       - /var/run/docker.sock:/var/run/docker.sock
+    container_name: server4
   server5:
     image: ansible-test-node
-    hostname: server4
+    hostname: server5
     volumes: 
       - /var/run/docker.sock:/var/run/docker.sock
+    container_name: server5

--- a/master/Dockerfile
+++ b/master/Dockerfile
@@ -10,8 +10,10 @@ RUN apt-get update \
 COPY id_rsa /root/.ssh/id_rsa
 COPY ansible_hosts /etc/ansible/hosts
 
+RUN chmod 400 /root/.ssh/id_rsa
+
 ENV ANSIBLE_HOST_KEY_CHECKING=False
 ENV EDITOR=/usr/bin/vi
 
-CMD echo docker exec -it ansible_master_1 bash
+CMD echo docker exec -it master bash
 CMD tail -f /dev/null


### PR DESCRIPTION
Sometimes creates an error for authorization file permission error when running the playbook. So id_rsa file permission set to read-only permission.